### PR TITLE
Stage 6/6: advanced queries

### DIFF
--- a/Web Quiz Engine (Kotlin)/task/src/engine/ControllerAdvice.kt
+++ b/Web Quiz Engine (Kotlin)/task/src/engine/ControllerAdvice.kt
@@ -32,4 +32,8 @@ class ControllerAdvice {
     @ExceptionHandler(QuizAuthorMismatchException::class)
     fun handleQuizAuthorMismatchException(e: QuizAuthorMismatchException) =
         ResponseEntity(mapOf("error" to e.message), HttpStatus.FORBIDDEN)
+
+    @ExceptionHandler(KotlinNullPointerException::class)
+    fun handleKotlinNullPointerException(e: KotlinNullPointerException) =
+        ResponseEntity(mapOf("error" to e.message), HttpStatus.INTERNAL_SERVER_ERROR)
 }

--- a/Web Quiz Engine (Kotlin)/task/src/engine/WebQuizApiController.kt
+++ b/Web Quiz Engine (Kotlin)/task/src/engine/WebQuizApiController.kt
@@ -1,15 +1,14 @@
 package engine
 
-import engine.model.AnswerQuizRequestBody
 import engine.entity.Quiz
-import engine.model.QuizDto
-import engine.model.QuizPostResponseBody
-import engine.model.RegisterUserRequestBody
+import engine.model.*
 import engine.service.QuizService
 import engine.service.QuizUserDetailsService
 import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -54,6 +53,13 @@ class WebQuizApiController(
 
     @GetMapping("/quizzes")
     @ResponseStatus(HttpStatus.OK)
-    fun getQuizList(): List<QuizDto> =
-        quizService.findQuizList()
+    fun getQuizPage(@PageableDefault(page = 0, size = 10) pageable: Pageable
+    ): Page<QuizDto> =
+        quizService.findQuizPage(pageable = pageable)
+
+    @GetMapping("/quizzes/completed")
+    @ResponseStatus(HttpStatus.OK)
+    fun getCompletedQuizList(@PageableDefault(page = 0, size = 10) pageable: Pageable
+    ): Page<QuizCompletionDto> =
+        quizService.findCompletedQuizPageForCurrentUser(pageable = pageable)
 }

--- a/Web Quiz Engine (Kotlin)/task/src/engine/WebQuizCompletionRepository.kt
+++ b/Web Quiz Engine (Kotlin)/task/src/engine/WebQuizCompletionRepository.kt
@@ -1,0 +1,14 @@
+package engine
+
+import engine.entity.QuizCompletion
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+typealias QuizCompletionIdentifier = Int
+
+@Repository
+interface WebQuizCompletionRepository: JpaRepository<QuizCompletion, QuizIdentifier> {
+    fun findAllByUserUserIdAndQuizIdIsNotNullAndCompletedAtIsNotNull(userId: Int, pageable: Pageable): Page<QuizCompletion>
+}

--- a/Web Quiz Engine (Kotlin)/task/src/engine/WebQuizRepository.kt
+++ b/Web Quiz Engine (Kotlin)/task/src/engine/WebQuizRepository.kt
@@ -1,10 +1,14 @@
 package engine
 
 import engine.entity.Quiz
-import org.springframework.data.repository.CrudRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 typealias QuizIdentifier = Int
 
 @Repository
-interface WebQuizRepository: CrudRepository<Quiz, QuizIdentifier>
+interface WebQuizRepository: JpaRepository<Quiz, QuizIdentifier> {
+    override fun findAll(pageable: Pageable): Page<Quiz>
+}

--- a/Web Quiz Engine (Kotlin)/task/src/engine/entity/QuizCompletion.kt
+++ b/Web Quiz Engine (Kotlin)/task/src/engine/entity/QuizCompletion.kt
@@ -1,0 +1,28 @@
+package engine.entity
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import engine.QuizCompletionIdentifier
+import jakarta.persistence.*
+import java.time.ZonedDateTime
+
+@Entity
+@Table(name = "completion")
+data class QuizCompletion(
+    @Id
+    @GeneratedValue
+    val id: QuizCompletionIdentifier? = null,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    var completedAt: ZonedDateTime? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id")
+    val quiz: Quiz,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: QuizUser
+) {
+    @PrePersist
+    @PreUpdate
+    fun setCompletedAt() {
+        completedAt = ZonedDateTime.now()
+    }
+}

--- a/Web Quiz Engine (Kotlin)/task/src/engine/model/QuizCompletionDto.kt
+++ b/Web Quiz Engine (Kotlin)/task/src/engine/model/QuizCompletionDto.kt
@@ -1,0 +1,11 @@
+package engine.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import engine.QuizIdentifier
+import java.time.ZonedDateTime
+
+data class QuizCompletionDto(
+    val id: QuizIdentifier,
+    @field:JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    val completedAt: ZonedDateTime
+)

--- a/Web Quiz Engine (Kotlin)/task/src/engine/service/QuizService.kt
+++ b/Web Quiz Engine (Kotlin)/task/src/engine/service/QuizService.kt
@@ -1,21 +1,22 @@
 package engine.service
 
+import engine.WebQuizCompletionRepository
 import engine.WebQuizRepository
-import engine.model.QuizPostResponseBody
-import engine.model.QuizPostResponseBodyCorrect
-import engine.model.QuizPostResponseBodyIncorrect
 import engine.exception.QuizNotFoundException
 import engine.entity.Quiz
-import engine.entity.QuizUser
+import engine.entity.QuizCompletion
 import engine.exception.QuizAuthorMismatchException
-import engine.model.QuizDto
+import engine.model.*
 import engine.util.SecurityUtil
-import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import java.time.ZonedDateTime
 
 @Service
 class QuizService(
     private val quizRepository: WebQuizRepository,
+    private val quizCompletionRepository: WebQuizCompletionRepository,
 ) {
 
     fun findQuizById(id: Int): QuizDto =
@@ -41,8 +42,8 @@ class QuizService(
             quizRepository.delete(this)
         }
 
-    fun findQuizList(): List<QuizDto> =
-        quizRepository.findAll().map { quiz ->
+    fun findQuizPage(pageable: Pageable): Page<QuizDto> =
+        quizRepository.findAll(pageable = pageable).map { quiz ->
             with(quiz) {
                 QuizDto(
                     id = id,
@@ -53,14 +54,34 @@ class QuizService(
             }
         }
 
+    fun findCompletedQuizPageForCurrentUser(pageable: Pageable): Page<QuizCompletionDto> =
+        quizCompletionRepository.findAllByUserUserIdAndQuizIdIsNotNullAndCompletedAtIsNotNull(
+            userId = SecurityUtil.authenticatedUser().userId!!,
+            pageable = pageable,
+            ).map { quizCompletion ->
+            with(quizCompletion) {
+                QuizCompletionDto(
+                    id = quiz.id!!, // nullable id is filtered out by the database query
+                    completedAt = completedAt!! //same
+                )
+            }
+        }
+
     fun checkQuizSolution(quizId: Int, answerList: List<Int>?): QuizPostResponseBody =
         findQuizByIdOrThrow(quizId)
             .let { quiz ->
             if ((quiz.answerList.isNullOrEmpty() && answerList.isNullOrEmpty()) ||
                 quiz.answerList?.size == answerList?.size &&
                 (quiz.answerList?.containsAll(answerList.orEmpty()) == true &&
-                        answerList?.containsAll(quiz.answerList) == true))
+                        answerList?.containsAll(quiz.answerList) == true)) {
+                quizCompletionRepository.save(
+                    QuizCompletion(
+                        quiz = quiz,
+                        user = SecurityUtil.authenticatedUser()
+                    )
+                )
                 QuizPostResponseBodyCorrect()
+            }
             else
                 QuizPostResponseBodyIncorrect()
         }


### PR DESCRIPTION
This pr introduces the required elements to support advanced queries

- add completion tracking
  - new entity
  - new dto
  - new repository
- add pagination on quizz list result
- 1 new endpoint
  - `/api/quizzes/completed` to retrieve completion stats for the user
  - supports pagination
- `KotlinNullException` exception handling

Pagination is done using standard Spring provided libraries


## For refrence, the hyperskil instructions

Advanced queries
Description

At this last stage, your service will be improved to perform some trickier requests and return paginated responses. From the client's point of view, only a small part of API will be changed here.

To get all existing quizzes in the service, the client sends the GET request to /api/quizzes as before. But here is the problem: the number of stored quizzes can be very large since your service is so popular among so many users.

In this regard, your API should return only 10 quizzes at once and support the ability to specify which portion of quizzes is needed (paging).

Please, use the standard libraries for the pagination.

Further, your API should return information about successful completions of quizzes by the authenticated user. This endpoint should also support paging.
Objectives

1 Update the endpoint for getting quizzes. Now it should accept the page parameter /api/quizzes?page={number} together with user authentication data so that the API supports the navigation through pages. The first page is 0 since pages start from zero, just like our quizzes.

The response should contains a JSON with quizzes (inside content) and some additional metadata:

{
  "totalPages":1,
  "totalElements":3,
  "last":true,
  "first":true,
  "sort":{ },
  "number":0,
  "numberOfElements":3,
  "size":10,
  "empty":false,
  "pageable": { },
  "content":[
    {"id":<quiz id>,"title":"<string>","text":"<string>","options":["<string>","<string>","<string>", ...]},
    {"id":<quiz id>,"title":"<string>","text":"<string>","options":["<string>", "<string>", ...]},
    {"id":<quiz id>,"title":"<string>","text":"<string>","options":["<string>","<string>", ...]}
  ]
}

We've simplified JSON a bit, but you can keep it in the same format it is generated by the framework when you return Page<T> instead of List<T>. Our tests will validate only the essential fields.

If there are no quizzes, content is empty []. If the user is authorized, the status code is 200 (OK); otherwise, it's 401 (UNAUTHORIZED).

2 Create the GET /api/quizzes/completed?page={number} endpoint that will accept the page parameter together with the user auth data to provide the specified part of all completions of quizzes for the authenticated user. Each completion should be represented by a JSON object in the following format:

{
  "id": <quiz id>,
  "completedAt": <DATE_TIME in ISO Date Time Format (yyyy-MM-dd'T'HH:mm:ss.SSSXXX)>
}

A response is divided into pages since the service may return a lot of data. It contains a JSON with quiz completions (inside content) and some additional metadata as in the previous operation.

Here is a response example:

{
  "totalPages":1,
  "totalElements":5,
  "last":true,
  "first":true,
  "empty":false,
  "content":[
    {"id":<quiz id>,"completedAt":"<date_time>"},
    {"id":<quiz id>,"completedAt":"<date_time>"},
    {"id":<quiz id>,"completedAt":"<date_time>"},
    {"id":<quiz id>,"completedAt":"<date_time>"},
    {"id":<quiz id>,"completedAt":"<date_time>"}
  ]
}

Since it is allowed to solve a quiz multiple times, the response may contain duplicate quizzes, but with the different completion date. The completions must be sorted by their completion time in descending order, i.e. newer completions first, older completions last.

We removed some metadata keys from the response to keep it comprehensible.

If there are no completed quizzes for the authenticated user, content is empty []. If the user is authenticated, the status code is 200 (OK); otherwise, it's 401 (UNAUTHORIZED).
A few words in the end

Good job! You can put this project on GitHub as an example of your work and your expertise. Just don't forget to write a clear description in the README and refer Hyperskill :) It may also be useful for you to get a code review, at least for the last stage of the project.

If you would like to continue the project, you can develop a web or mobile client for this web service.
Examples

Example 1: getting the first page of the total list of quizzes with a valid authentication:

Request: GET /api/quizzes?page=1

Response code: 200 OK

Response body:

{
  "totalPages":1,
  "totalElements":3,
  "last":true,
  "first":true,
  "sort":{ },
  "number":0,
  "numberOfElements":3,
  "size":10,
  "empty":false,
  "pageable": { },
  "content":[
    {"id":102,"title":"Test 1","text":"Text 1","options":["a","b","c"]},
    {"id":103,"title":"Test 2","text":"Text 2","options":["a", "b", "c", "d"]},
    {"id":202,"title":"The Java Logo","text":"What is depicted on the Java logo?",
     "options":["Robot","Tea leaf","Cup of coffee","Bug"]}
  ]
}

Example 2: getting the first page of the total list of quizzes with an invalid authentication:

Request: GET /api/quizzes?page=1

Response: 401 UNAUTHORIZED

Example 3: getting the first page of the total list of quiz completions for the authenticated user:

Request: GET /api/quizzes/completed?page=1

Response code: 200 OK

Response body:

{
  "totalPages":1,
  "totalElements":5,
  "last":true,
  "first":true,
  "empty":false,
  "content":[
    {"id":103,"completedAt":"2019-10-29T21:13:53.779542"},
    {"id":102,"completedAt":"2019-10-29T21:13:52.324993"},
    {"id":101,"completedAt":"2019-10-29T18:59:58.387267"},
    {"id":101,"completedAt":"2019-10-29T18:59:55.303268"},
    {"id":202,"completedAt":"2019-10-29T18:59:54.033801"}
  ]
}

Example 4: getting the first page of the total list of quiz completions with an invalid authentication:

Request: GET /api/quizzes/completed?page=1

Response: 401 UNAUTHORIZED